### PR TITLE
Relax Content-Security-Policy for index page

### DIFF
--- a/internal/ydls/handler.go
+++ b/internal/ydls/handler.go
@@ -90,7 +90,7 @@ func (yh *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Path == "/" && r.URL.RawQuery == "" {
 		if yh.IndexTmpl != nil {
-			w.Header().Set("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; form-action 'self'")
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'unsafe-inline'; form-action 'self'")
 			yh.IndexTmpl.Execute(w, yh.YDLS.Config.Formats)
 		} else {
 			http.Error(w, "Not found", http.StatusNotFound)


### PR DESCRIPTION
With this PR, it is now possible to use something like this as the index template:

```html
<!doctype html>

<html lang="en">
<head>
  <meta charset="utf-8">
  <title>Relax CSP demo</title>
</head>

<body>
  <audio controls>
    <source src="/ogg/https://youtu.be/dQw4w9WgXcQ" type="audio/ogg">
    Your browser does not support the audio element.
  </audio>
</body>
</html>
```