### PR TITLE
Update youtube-dl from 2021.01.24.1 to 2021.02.04.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # bump: youtube-dl /YDL_VERSION=([\d.]+)/ https://github.com/ytdl-org/youtube-dl.git|/^\d/|sort
 # bump: youtube-dl link "Release notes" https://github.com/ytdl-org/youtube-dl/releases/tag/$LATEST
-ARG YDL_VERSION=2021.01.24.1
+ARG YDL_VERSION=2021.02.04.1
 # bump: static-ffmpeg /FFMPEG_VERSION=([\d.-]+)/ docker:mwader/static-ffmpeg|/^\d/|sort
 ARG FFMPEG_VERSION=4.3.1-2
 # bump: golang /GOLANG_VERSION=([\d.]+)/ docker:golang|^1


### PR DESCRIPTION
[Release notes](https://github.com/ytdl-org/youtube-dl/releases/tag/2021.02.04.1)  
