### PR TITLE
Add av1 codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ can handle most format and codecs. Default configuration can transcode to these 
 |mp3|mp3|mp3|||
 |ogg|ogg|vorbis, opus|||
 |wav|wav|pcm_s16le|||
-|mkv|matroska|aac, ac3, mp3, vorbis, opus, flac, alac|h264, hevc, vp8, vp9, theora|subrip, ass|
-|mp4|mov|aac, flac, alac, mp3, vorbis|h264, hevc|mov_text|
+|mkv|matroska|aac, mp3, vorbis, opus, flac, alac, ac3|h264, theora, av1, hevc, vp8, vp9|subrip, ass|
+|mp4|mov|aac, mp3, vorbis, flac, alac|h264, hevc, av1|mov_text|
 |mxf|mxf|pcm_s16le|mpeg2video||
 |ts|mpegts|aac, mp3, ac3|h264, hevc||
-|webm|webm|vorbis, opus|vp8, vp9|webvtt|
+|webm|webm|vorbis, opus|vp8, vp9, av1|webvtt|
 |rss|mp3|mp3|||
 
 The `rss` format transforms a playlist into a RSS audio podcast.

--- a/_dev/markdown-formats.go
+++ b/_dev/markdown-formats.go
@@ -34,8 +34,8 @@ func main() {
 		return false
 	})
 
-	fmt.Print("|Format name|Container|Audio codecs|Video codecs|Subtitle codecs\n")
-	fmt.Print("|-|-|-|-|\n")
+	fmt.Print("|Format|Container|Audio|Video|Subtitle|\n")
+	fmt.Print("|-|-|-|-|-|\n")
 	for _, f := range formats {
 		var aCodecs []string
 		var vCodecs []string

--- a/internal/ydls/config_test.go
+++ b/internal/ydls/config_test.go
@@ -66,9 +66,9 @@ func TestFFmpegHasFormatsCodecs(t *testing.T) {
 
 			ffmpegP := &ffmpeg.FFmpeg{
 				Streams: []ffmpeg.Stream{
-					ffmpeg.Stream{
+					{
 						Maps: []ffmpeg.Map{
-							ffmpeg.Map{
+							{
 								Input:     ffmpeg.Reader{Reader: dummyReader},
 								Specifier: codec.specifier,
 								Codec:     ffcodec,
@@ -78,8 +78,8 @@ func TestFFmpegHasFormatsCodecs(t *testing.T) {
 						Output: ffmpeg.Writer{Writer: output},
 					},
 				},
-				DebugLog: nil, //log.New(os.Stdout, "debug> ", 0),
-				Stderr:   nil, //printwriter.New(log.New(os.Stdout, "stderr> ", 0), ""),
+				// DebugLog: log.New(os.Stdout, "debug> ", 0),
+				// Stderr:   printwriter.New(log.New(os.Stdout, "stderr> ", 0)),
 			}
 
 			if err := ffmpegP.Start(context.Background()); err != nil {

--- a/internal/ydls/ydls.go
+++ b/internal/ydls/ydls.go
@@ -117,6 +117,7 @@ func ffmpegCodecFromYDLCodec(c string) (string, bool) {
 		"mp4a": "aac",
 		"mp4v": "h264",
 		"h265": "hevc",
+		"av01": "av1",
 	}
 
 	// "  NAME.something  " -> "name"

--- a/ydls.json
+++ b/ydls.json
@@ -11,7 +11,8 @@
     "mp3": "libmp3lame",
     "vorbis": "libvorbis",
     "opus": "libopus",
-    "aac": "libfdk_aac"
+    "aac": "libfdk_aac",
+    "av1": "libsvtav1"
   },
   "Formats": {
     "rss": {
@@ -136,7 +137,7 @@
       ],
       "FormatFlags": [
         "-movflags",
-        "isml+frag_keyframe"
+        "+isml+frag_keyframe"
       ],
       "Streams": [
         {
@@ -159,7 +160,8 @@
           "Specifier": "v:0",
           "Codecs": [
             "h264",
-            "hevc"
+            "hevc",
+            "av1"
           ]
         }
       ],
@@ -186,7 +188,8 @@
           "Specifier": "v:0",
           "Codecs": [
             "vp8",
-            "vp9"
+            "vp9",
+            "av1"
           ]
         }
       ],
@@ -220,7 +223,8 @@
             "hevc",
             "vp8",
             "vp9",
-            "theora"
+            "theora",
+            "av1"
           ]
         }
       ],


### PR DESCRIPTION
Both librav1e and liboam-av1 seems to have problem when using pipe output, but libsvtav1
seem to work fine

librav1e fails: ffmpeg -v trace -hide_banner -y -f lavfi -i testsrc -c:v librav1e -t 100ms -f matroska pipe:1 > test.mkv
libaom-av1 segfault: ffmpeg -v trace -hide_banner -y -f lavfi -i testsrc -t 1s -c:v libaom-av1 -f null -