### PR TITLE
Update golang from 1.18.0 to 1.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG YT_DLP=2022.04.08
 ARG FFMPEG_VERSION=5.0.1
 # bump: golang /GOLANG_VERSION=([\d.]+)/ docker:golang|^1
 # bump: golang link "Release notes" https://golang.org/doc/devel/release.html
-ARG GOLANG_VERSION=1.18.0
+ARG GOLANG_VERSION=1.18.1
 # bump: alpine /ALPINE_VERSION=([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
 ARG ALPINE_VERSION=3.15.4


### PR DESCRIPTION
[Release notes](https://golang.org/doc/devel/release.html)  
