### PR TITLE
Update alpine from 3.16.0 to 3.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG FFMPEG_VERSION=5.0.1-3
 ARG GOLANG_VERSION=1.18.4
 # bump: alpine /ALPINE_VERSION=([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-ARG ALPINE_VERSION=3.16.0
+ARG ALPINE_VERSION=3.16.1
 
 FROM mwader/static-ffmpeg:$FFMPEG_VERSION AS ffmpeg
 


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.16.1-released.html)  
