### PR TITLE
Update alpine to 3.16.3 from 3.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG FFMPEG_VERSION=5.1.2
 ARG GOLANG_VERSION=1.19.3
 # bump: alpine /ALPINE_VERSION=([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-ARG ALPINE_VERSION=3.16.2
+ARG ALPINE_VERSION=3.16.3
 
 FROM mwader/static-ffmpeg:$FFMPEG_VERSION AS ffmpeg
 


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.16.3-released.html)  
