### PR TITLE
Make format streams optional by default

### DIFF
--- a/internal/ydls/config.go
+++ b/internal/ydls/config.go
@@ -65,6 +65,7 @@ func (f *Format) UnmarshalJSON(b []byte) (err error) {
 }
 
 type Stream struct {
+	Required  bool
 	Specifier string
 	Codecs    []Codec
 

--- a/internal/ydls/ydls_test.go
+++ b/internal/ydls/ydls_test.go
@@ -159,7 +159,8 @@ func TestMissingMediaStream(t *testing.T) {
 	defer leakChecks(t)()
 
 	ydls := ydlsFromEnv(t)
-	const formatName = "mkv"
+	// mxf requires video, soundcloud is audio only
+	const formatName = "mxf"
 	mkvFormat, _ := ydls.Config.Formats.FindByName(formatName)
 
 	ctx, cancelFn := context.WithCancel(context.Background())

--- a/ydls.json
+++ b/ydls.json
@@ -268,6 +268,7 @@
       ],
       "Streams": [
         {
+          "Required": true,
           "Specifier": "v:0",
           "Codecs": [
             {


### PR DESCRIPTION
Makes it possible to for example output mp4 with only one audio or video stream. Fail if no steams are found and also fail if a required steam if not found.