### PR TITLE
Update golang to 1.26.6 from 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG YT_DLP=2026.06.09
 ARG FFMPEG_VERSION=9.0
 # bump: golang /GOLANG_VERSION=([\d.]+)/ docker:golang|^1
 # bump: golang link "Release notes" https://golang.org/doc/devel/release.html
-ARG GOLANG_VERSION=1.26.4
+ARG GOLANG_VERSION=1.26.6
 # bump: alpine /ALPINE_VERSION=([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
 ARG ALPINE_VERSION=3.24.1


### PR DESCRIPTION
[Release notes](https://golang.org/doc/devel/release.html)  
